### PR TITLE
Add login/register UI and controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ bin/
 !.env.example
 data/*.mv.db  # Ignoriert alle .mv.db-Dateien im data-Ordner
 
+data/chatdb.mv.db

--- a/src/main/java/Client/ControllerLogin.java
+++ b/src/main/java/Client/ControllerLogin.java
@@ -1,0 +1,84 @@
+package Client;
+
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.PasswordField;
+import javafx.scene.control.TextField;
+import javafx.stage.Stage;
+
+import java.io.IOException;
+
+public class ControllerLogin {
+
+	@FXML
+	private TextField usernameField;
+
+	@FXML
+	private PasswordField passwordField;
+
+	@FXML
+	private Button loginButton;
+
+	@FXML
+	private Label registerLink;
+
+	private Stage stage;
+
+	@FXML
+	private void initialize() {
+		loginButton.setOnAction(e -> handleLogin());
+		registerLink.setOnMouseClicked(e -> handleRegisterClick());
+	}
+
+	public void setStage(Stage stage) {
+		this.stage = stage;
+	}
+
+	private void handleLogin() {
+		String username = usernameField.getText().trim();
+		String password = passwordField.getText();
+
+		if (validateInput(username, password)) {
+			System.out.println("Login-Versuch für: " + username);
+			// TODO: Login-Anfrage an den Server senden
+		}
+	}
+
+	private void handleRegisterClick() {
+		try {
+			FXMLLoader registerLoader = new FXMLLoader(getClass().getResource("/Client/registerScreen.fxml"));
+			Parent registerRoot = registerLoader.load();
+
+			ControllerRegister registerController = registerLoader.getController();
+			registerController.setStage(stage);
+
+			Scene scene = new Scene(registerRoot, 1280, 720);
+			stage.setTitle("Socket Chat - Registrierung");
+			stage.setScene(scene);
+		} catch (IOException e) {
+			System.err.println("Fehler beim Laden des Registrierungsbildschirms: " + e.getMessage());
+			e.printStackTrace();
+		}
+	}
+
+	private boolean validateInput(String username, String password) {
+		if (username.isEmpty()) {
+			showError("Benutzername ist erforderlich");
+			return false;
+		}
+		if (password.isEmpty()) {
+			showError("Passwort ist erforderlich");
+			return false;
+		}
+		return true;
+	}
+
+	private void showError(String message) {
+		System.err.println("Fehler: " + message);
+		// TODO: Fehlermeldung in der UI anzeigen
+	}
+}

--- a/src/main/java/Client/ControllerRegister.java
+++ b/src/main/java/Client/ControllerRegister.java
@@ -1,0 +1,58 @@
+package Client;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.PasswordField;
+import javafx.scene.control.TextField;
+import javafx.stage.Stage;
+
+public class ControllerRegister {
+
+	@FXML
+	private TextField usernameField;
+
+	@FXML
+	private PasswordField passwordField;
+
+	@FXML
+	private Button registerButton;
+
+	private Stage stage;
+
+	@FXML
+	private void initialize() {
+		registerButton.setOnAction(e -> handleRegister());
+	}
+
+	public void setStage(Stage stage) {
+		this.stage = stage;
+	}
+
+	private void handleRegister() {
+		String username = usernameField.getText().trim();
+		String password = passwordField.getText();
+
+		if (validateInput(username, password)) {
+			System.out.println("Registrierungsversuch für: " + username);
+			// TODO: Registrierungs-Anfrage an den Server senden
+		}
+	}
+
+	private boolean validateInput(String username, String password) {
+		if (username.isEmpty()) {
+			showError("Benutzername ist erforderlich");
+			return false;
+		}
+		if (password.isEmpty()) {
+			showError("Passwort ist erforderlich");
+			return false;
+		}
+		return true;
+	}
+
+	private void showError(String message) {
+		System.err.println("Fehler: " + message);
+		// TODO: Fehlermeldung in der UI anzeigen
+	}
+}
+

--- a/src/main/java/Client/Main.java
+++ b/src/main/java/Client/Main.java
@@ -17,22 +17,18 @@ public class Main extends Application {
 
 	@Override
 	public void start(Stage primaryStage) throws IOException {
-		FXMLLoader loader = new FXMLLoader(Main.class.getResource("/Client/chat-view.fxml"));
-		Parent root = loader.load();
+		// Login-Bildschirm laden
+		FXMLLoader loginLoader = new FXMLLoader(Main.class.getResource("/Client/loginScreen.fxml"));
+		Parent loginRoot = loginLoader.load();
 
-		Controller controller = loader.getController();
+		ControllerLogin loginController = loginLoader.getController();
+		loginController.setStage(primaryStage);
 
-		User user = new User();
-		user.setUsername("Benutzername");
-		controller.configure(primaryStage, user);
-
-		Scene scene = new Scene(root, 500, 650);
-		primaryStage.setTitle("Socket Chat");
+		Scene scene = new Scene(loginRoot, 1280, 720);
+		primaryStage.setTitle("Socket Chat - Login");
 		primaryStage.setScene(scene);
 		primaryStage.setMinWidth(350);
 		primaryStage.setMinHeight(400);
 		primaryStage.show();
-
-		controller.connectAndRun("127.0.0.1", 6969);
 	}
 }

--- a/src/main/resources/Client/loginScreen.fxml
+++ b/src/main/resources/Client/loginScreen.fxml
@@ -15,7 +15,7 @@
 <?import javafx.scene.paint.Stop?>
 <?import javafx.scene.shape.Circle?>
 
-<GridPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="720.0" prefWidth="1280.0" styleClass="grid-pane" stylesheets="@styleLoginScreen.css" xmlns="http://javafx.com/javafx/25" xmlns:fx="http://javafx.com/fxml/1">
+<GridPane fx:controller="Client.ControllerLogin" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="720.0" prefWidth="1280.0" styleClass="grid-pane" stylesheets="@styleLoginScreen.css" xmlns="http://javafx.com/javafx/25" xmlns:fx="http://javafx.com/fxml/1">
   <columnConstraints>
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" percentWidth="50.0" prefWidth="100.0" />
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" percentWidth="50.0" prefWidth="100.0" />
@@ -57,22 +57,22 @@
                   <Insets bottom="10.0" />
                </VBox.margin>
             </Label>
-            <TextField maxWidth="250.0" promptText="Benutzername" styleClass="rounded">
-               <VBox.margin>
-                  <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-               </VBox.margin>
-            </TextField>
-            <PasswordField maxWidth="250.0" promptText="Passwort" styleClass="rounded">
-               <VBox.margin>
-                  <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-               </VBox.margin>
-            </PasswordField>
-            <Button mnemonicParsing="false" prefWidth="250.0" styleClass="rounded" text="Login">
-               <VBox.margin>
-                  <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
-               </VBox.margin>
-            </Button>
-            <Label styleClass="hyperlink" text="Registrieren &gt;" textFill="#0a84ff">
+             <TextField fx:id="usernameField" maxWidth="250.0" promptText="Benutzername" styleClass="rounded">
+                <VBox.margin>
+                   <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                </VBox.margin>
+             </TextField>
+             <PasswordField fx:id="passwordField" maxWidth="250.0" promptText="Passwort" styleClass="rounded">
+                <VBox.margin>
+                   <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                </VBox.margin>
+             </PasswordField>
+             <Button fx:id="loginButton" mnemonicParsing="false" prefWidth="250.0" styleClass="rounded" text="Login">
+                <VBox.margin>
+                   <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
+                </VBox.margin>
+             </Button>
+             <Label fx:id="registerLink" styleClass="hyperlink" text="Registrieren &gt;" textFill="#0a84ff">
                <VBox.margin>
                   <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
                </VBox.margin>

--- a/src/main/resources/Client/registerScreen.fxml
+++ b/src/main/resources/Client/registerScreen.fxml
@@ -15,7 +15,7 @@
 <?import javafx.scene.paint.Stop?>
 <?import javafx.scene.shape.Circle?>
 
-<GridPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="720.0" prefWidth="1280.0" styleClass="grid-pane" stylesheets="@styleRegisterScreen.css" xmlns="http://javafx.com/javafx/25" xmlns:fx="http://javafx.com/fxml/1">
+<GridPane fx:controller="Client.ControllerRegister" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="720.0" prefWidth="1280.0" styleClass="grid-pane" stylesheets="@styleRegisterScreen.css" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
   <columnConstraints>
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" percentWidth="50.0" prefWidth="100.0" />
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" percentWidth="50.0" prefWidth="100.0" />
@@ -57,17 +57,17 @@
                   <Insets bottom="10.0" />
                </VBox.margin>
             </Label>
-            <TextField maxWidth="250.0" promptText="Username" styleClass="rounded">
+            <TextField fx:id="usernameField" maxWidth="250.0" promptText="Username" styleClass="rounded">
                <VBox.margin>
                   <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
                </VBox.margin>
             </TextField>
-            <PasswordField maxWidth="250.0" promptText="Password" styleClass="rounded">
+            <PasswordField fx:id="passwordField" maxWidth="250.0" promptText="Password" styleClass="rounded">
                <VBox.margin>
                   <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
                </VBox.margin>
             </PasswordField>
-            <Button mnemonicParsing="false" prefWidth="250.0" styleClass="rounded" text="Register">
+            <Button fx:id="registerButton" mnemonicParsing="false" prefWidth="250.0" styleClass="rounded" text="Register">
                <VBox.margin>
                   <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
                </VBox.margin>


### PR DESCRIPTION
Introduce login and registration screens and controllers: add ControllerLogin and ControllerRegister (with basic input validation, UI hooks and TODOs for server requests) and wire fx:controller/fx:id fields in loginScreen.fxml and registerScreen.fxml. Update Main to load the login screen on startup and pass the primary stage to the login controller. Update .gitignore to ignore data/chatdb.mv.db. These changes set up the UI flow for authentication and prepare for integrating server-side login/register logic.