### PR TITLE
Add group management and improve user interface

### DIFF
--- a/src/main/java/Client/Client.java
+++ b/src/main/java/Client/Client.java
@@ -39,6 +39,10 @@ public class Client implements Runnable {
 		this.in = in;
 	}
 
+	public void disconnect() {
+		try { socket.getSocket().close(); } catch (IOException ignored) {}
+	}
+
 	@Override
 	public void run() {
 		Thread sender = new Thread(() -> {

--- a/src/main/java/Client/Controller.java
+++ b/src/main/java/Client/Controller.java
@@ -16,6 +16,7 @@ import Util.Network.Auth.RegisterResponse;
 import Util.Network.ConnectionClosed;
 import Util.Network.DeleteForMeMessage;
 import Util.Network.DeleteMessage;
+import Util.Network.Groups.AddMemberPacket;
 import Util.Network.Groups.CreateGroupPacket;
 import Util.Network.Groups.Group;
 import Util.Network.Groups.GroupCreatedPacket;
@@ -190,13 +191,15 @@ public class Controller {
 		sendButton.setOnAction(e -> sendMessage());
 		messageTextField.setOnAction(e -> sendMessage());
 		uploadButton.setOnAction(e -> openUploadMenu());
-		videoCallButton.setOnAction(e -> handleCallButton());
-
-		if (buttonEmoji != null) {
-			buttonEmoji.setOnAction(e -> openEmojiPicker());
+		if (videoCallButton != null) {
+			videoCallButton.setOnAction(e -> handleCallButton());
 		}
 		if (videoButton != null) {
 			videoButton.setOnAction(e -> handleVideoButton());
+		}
+
+		if (buttonEmoji != null) {
+			buttonEmoji.setOnAction(e -> openEmojiPicker());
 		}
 
 		if (userListView != null) {
@@ -614,8 +617,18 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 			case JoinNotification join -> {
 				cacheProfilePicture(join.getUser());
 				addUserToList(join.getUser());
+				// Join-Nachricht im globalen Chat anzeigen
+				if (activeGroup == null && activePrivateChat == null) {
+					getMessages().add(join);
+				}
 			}
-			case LeaveNotification leave -> removeUserFromList(leave.getUser());
+			case LeaveNotification leave -> {
+				removeUserFromList(leave.getUser());
+				// Leave-Nachricht im globalen Chat anzeigen
+				if (activeGroup == null && activePrivateChat == null) {
+					getMessages().add(leave);
+				}
+			}
 			case null, default -> throw new IllegalStateException("Unbekannte Systemnachricht");
 		}
 	}
@@ -653,16 +666,7 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 			updateWelcomeLabel();
 			addUserToList(localUser);
 			updateOwnProfilePictureView();
-			// Nach erfolgreichem Login: lade Chat-History vom Server
-			try {
-				HistoryRequest histReq = new HistoryRequest();
-				histReq.setSender(localUser.getUsername());  // Sender = aktueller Benutzer
-				histReq.setReceiver(null);                   // Global chat
-				histReq.setChatRoomId("main");               // Standard chat room für globale Nachrichten
-				outPacketQueue.put(histReq);
-			} catch (InterruptedException e) {
-				System.err.println("Fehler beim Senden von HistoryRequest: " + e.getMessage());
-			}
+			openGlobalChat();
 		}
 		if (onLoginResult != null) {
 			onLoginResult.accept(response);
@@ -1032,10 +1036,7 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 		}
 
 		private boolean canShowContextMenu(Message message) {
-			// Für alle gelöschte Nachrichten: kein Menü mehr nötig
-			if (message instanceof TextMessage tm) return !tm.isDeleted();
-			if (message instanceof FileMessage fm) return !fm.isDeleted();
-			return false;
+			return message instanceof TextMessage || message instanceof FileMessage;
 		}
 
 		private ContextMenu createMessageContextMenu(Message message, boolean isOwn) {
@@ -1050,7 +1051,10 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 
 			menu.getItems().add(deleteForMeItem);
 
-			if (isOwn) {
+			boolean isDeleted = (message instanceof TextMessage tm && tm.isDeleted())
+				|| (message instanceof FileMessage fm && fm.isDeleted());
+
+			if (isOwn && !isDeleted) {
 				MenuItem deleteForAllItem = new MenuItem("Für alle löschen");
 				deleteForAllItem.setOnAction(event -> Controller.this.deleteMessage(message));
 				menu.getItems().add(deleteForAllItem);
@@ -1173,6 +1177,21 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 		sendPacket(new DeleteMessage(message.getMessageId()));
 	}
 
+	public void disconnect() {
+		if (client != null) client.disconnect();
+	}
+
+	private void showAddMemberDialog(UUID groupId) {
+		TextInputDialog dialog = new TextInputDialog();
+		dialog.setTitle("Mitglied hinzufügen");
+		dialog.setHeaderText("Benutzername eingeben:");
+		Main.themed(dialog).showAndWait().ifPresent(username -> {
+			if (!username.isBlank()) {
+				sendPacket(new AddMemberPacket(groupId, username.trim()));
+			}
+		});
+	}
+
 	//Audio
 	public void stopCall() {
 		if (inCall || pendingCall) {
@@ -1267,13 +1286,14 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 		inCall = false;
 		pendingCall = false;
 		callPeer = null;
-		videoCallButton.getStyleClass().remove("call-active");
-		videoButton.getStyleClass().remove("call-active");
+		if (videoCallButton != null) videoCallButton.getStyleClass().remove("call-active");
+		if (videoButton != null) videoButton.getStyleClass().remove("call-active");
 	}
 
 	// Markiert den zur Anrufart passenden Button rot (call-active) bzw. entfernt die Markierung.
 	private void setCallButtonActive(boolean video, boolean active) {
 		Button button = video ? videoButton : videoCallButton;
+		if (button == null) return;
 		if (active) {
 			if (!button.getStyleClass().contains("call-active")) {
 				button.getStyleClass().add("call-active");
@@ -1416,6 +1436,7 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 			super.updateItem(item, empty);
 			setText(null);
 			setGraphic(null);
+			setContextMenu(null);
 			if (empty || item == null) return;
 
 			Label label = new Label(item.displayName());
@@ -1426,15 +1447,11 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 			box.setPadding(new Insets(6, 10, 6, 10));
 
 			if (item.type() == ChatEntry.Type.GROUP) {
-				Button joinBtn = new Button("ID");
-				joinBtn.setStyle("-fx-font-size: 9;");
-				joinBtn.setOnAction(e -> {
-					Alert alert = new Alert(Alert.AlertType.INFORMATION);
-					alert.setHeaderText("Gruppen-ID");
-					alert.setContentText(item.groupId().toString());
-					Main.themed(alert).show();
-				});
-				box.getChildren().add(joinBtn);
+				ContextMenu ctx = new ContextMenu();
+				MenuItem addMember = new MenuItem("Mitglied hinzufügen");
+				addMember.setOnAction(e -> showAddMemberDialog(item.groupId()));
+				ctx.getItems().add(addMember);
+				setContextMenu(ctx);
 			}
 
 			setGraphic(box);

--- a/src/main/java/Client/Controller.java
+++ b/src/main/java/Client/Controller.java
@@ -19,6 +19,11 @@ import Util.Network.DeleteMessage;
 import Util.Network.GetUsersRequest;
 import Util.Network.GetUsersResponse;
 import Util.Network.Groups.AddMemberPacket;
+import Util.Network.Groups.GetGroupMembersRequest;
+import Util.Network.Groups.GetGroupMembersResponse;
+import Util.Network.Groups.GroupRemovedNotification;
+import Util.Network.Groups.RemoveMemberPacket;
+import Util.Network.Groups.RemovedGroupsResponse;
 import Util.Network.Groups.CreateGroupPacket;
 import Util.Network.Groups.Group;
 import Util.Network.Groups.GroupCreatedPacket;
@@ -103,6 +108,12 @@ public class Controller {
 
 	private final ObservableList<ChatEntry> chatList = FXCollections.observableArrayList();
 	private final ObservableList<User> allKnownUsers = FXCollections.observableArrayList();
+	// Bekannte Gruppenmitglieder je Gruppe (wird vom Server geladen)
+	private final Map<UUID, Set<String>> groupMemberCache = new HashMap<>();
+	// Ersteller je Gruppe (wird mit GetGroupMembersResponse gesetzt)
+	private final Map<UUID, String> groupCreatorCache = new HashMap<>();
+	// Gruppen aus denen der User entfernt wurde – nur lesen, nicht schreiben
+	private final Set<UUID> removedGroups = new java.util.HashSet<>();
 	private final Map<String, byte[]> profilePicturesByUsername = new HashMap<>();
 	private final Map<String, String> profilePictureContentTypesByUsername = new HashMap<>();
 	private boolean profilePictureSyncEnabled;
@@ -324,10 +335,42 @@ public class Controller {
 								addGroupToChatList(created.getGroup());
 								openGroupChat(created.getGroup());
 							});
-							case GetUsersResponse resp -> Platform.runLater(() -> {
-							allKnownUsers.setAll(resp.getUsers());
-						});
-						case ProfilePictureUpdate update -> Platform.runLater(() -> applyProfilePictureUpdate(update));
+							case GetUsersResponse resp -> Platform.runLater(() ->
+								allKnownUsers.setAll(resp.getUsers()));
+							case GetGroupMembersResponse resp -> Platform.runLater(() -> {
+								groupMemberCache.put(resp.getGroupId(), resp.getUsernames());
+								if (resp.getCreatorUsername() != null)
+									groupCreatorCache.put(resp.getGroupId(), resp.getCreatorUsername());
+							});
+							case RemovedGroupsResponse resp -> Platform.runLater(() -> {
+								for (Map.Entry<String, String> entry : resp.getRemovedGroups().entrySet()) {
+									try {
+										UUID gid = UUID.fromString(entry.getKey());
+										removedGroups.add(gid);
+										boolean alreadyInList = chatList.stream()
+											.anyMatch(e -> e.type() == ChatEntry.Type.GROUP && gid.equals(e.groupId()));
+										if (!alreadyInList) {
+											chatList.add(new ChatEntry(ChatEntry.Type.GROUP, entry.getValue(), gid, null));
+										}
+									} catch (IllegalArgumentException ignored) {}
+								}
+							});
+							case GroupRemovedNotification notif -> Platform.runLater(() -> {
+								removedGroups.add(notif.getGroupId());
+								groupMemberCache.remove(notif.getGroupId());
+								// Gruppe bleibt in der Liste – nur Input sperren wenn gerade offen
+								if (activeGroup != null && activeGroup.getId().equals(notif.getGroupId())) {
+									getMessages().add(new TextMessage(null,
+										"Du wurdest von " + notif.getRemovedBy() + " aus dieser Gruppe entfernt."));
+									setInputEnabled(false);
+								}
+								Alert alert = new Alert(Alert.AlertType.INFORMATION);
+								alert.setTitle("Aus Gruppe entfernt");
+								alert.setHeaderText("Du wurdest aus \"" + notif.getGroupName() + "\" entfernt.");
+								alert.setContentText("Entfernt von: " + notif.getRemovedBy());
+								Main.themed(alert).show();
+							});
+							case ProfilePictureUpdate update -> Platform.runLater(() -> applyProfilePictureUpdate(update));
 							case ConnectionClosed closed -> Platform.runLater(() -> handleConnectionClosed(closed));
 							case LoginResponse loginResp -> Platform.runLater(() -> { //FÜR UI CALLBACK
 								handleLoginResponse(loginResp);
@@ -734,6 +777,7 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 		addPrivateChatToChatList(user.getUsername(), getDisplayName(user));
 		if (chatHeaderLabel != null) chatHeaderLabel.setText(getDisplayName(user));
 		getMessages().clear();
+		setInputEnabled(true);
 		outPacketQueue.offer(new HistoryRequest(localUser.getUsername(), user.getUsername(), null));
 	}
 
@@ -759,6 +803,7 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 		activeGroup = null;
 		if (chatHeaderLabel != null) chatHeaderLabel.setText("Globaler Chat");
 		getMessages().clear();
+		setInputEnabled(true);
 		outPacketQueue.offer(new HistoryRequest(localUser.getUsername(), null, "main"));
 	}
 
@@ -767,6 +812,7 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 		activeGroup = group;
 		if (chatHeaderLabel != null) chatHeaderLabel.setText(group.getName());
 		getMessages().clear();
+		setInputEnabled(!removedGroups.contains(group.getId()));
 		outPacketQueue.offer(new HistoryRequest(localUser.getUsername(), null, group.getId().toString()));
 	}
 
@@ -775,8 +821,9 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 		switch (entry.type()) {
 			case GLOBAL -> openGlobalChat();
 			case GROUP -> {
-				// Gruppe beitreten falls noch nicht Mitglied, dann öffnen
-				outPacketQueue.offer(new JoinGroupPacket(entry.groupId()));
+				// Nur beitreten wenn noch nicht entfernt
+				if (!removedGroups.contains(entry.groupId()))
+					outPacketQueue.offer(new JoinGroupPacket(entry.groupId()));
 				openGroupChat(new Group(entry.groupId(), entry.displayName(), ""));
 			}
 			case PRIVATE -> {
@@ -784,6 +831,7 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 				activeGroup = null;
 				if (chatHeaderLabel != null) chatHeaderLabel.setText(entry.displayName());
 				getMessages().clear();
+				setInputEnabled(true);
 				outPacketQueue.offer(new HistoryRequest(localUser.getUsername(), entry.username(), null));
 			}
 		}
@@ -1185,15 +1233,42 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 		sendPacket(new DeleteMessage(message.getMessageId()));
 	}
 
+	private void setInputEnabled(boolean enabled) {
+		if (messageTextField != null) messageTextField.setDisable(!enabled);
+		if (sendButton != null) sendButton.setDisable(!enabled);
+		if (uploadButton != null) uploadButton.setDisable(!enabled);
+		if (messageTextField != null) messageTextField.setPromptText(enabled
+			? "Nachricht eingeben ..."
+			: "Du wurdest aus dieser Gruppe entfernt.");
+	}
+
 	public void disconnect() {
 		if (client != null) client.disconnect();
 	}
 
 	private void showAddMemberDialog(UUID groupId) {
-		// Aktuelle Liste vom Server anfordern, dann Dialog öffnen
+		// Mitgliederliste und Userliste vom Server frisch laden
 		outPacketQueue.offer(new GetUsersRequest());
+		outPacketQueue.offer(new GetGroupMembersRequest(groupId));
 
-		// Kandidaten: alle bekannten User außer dem eigenen Account
+		// Warten im Hintergrund-Thread, danach Dialog auf JavaFX-Thread öffnen
+		Thread loader = new Thread(() -> {
+			long deadline = System.currentTimeMillis() + 2000;
+			while (System.currentTimeMillis() < deadline) {
+				if (!allKnownUsers.isEmpty() && groupMemberCache.containsKey(groupId)) break;
+				try { Thread.sleep(50); } catch (InterruptedException e) { Thread.currentThread().interrupt(); return; }
+			}
+			Platform.runLater(() -> openAddMemberDialogUI(groupId));
+		}, "AddMemberLoader");
+		loader.setDaemon(true);
+		loader.start();
+	}
+
+	private void openAddMemberDialogUI(UUID groupId) {
+		Set<String> existingMembers = groupMemberCache.getOrDefault(groupId, Set.of());
+		String creatorUsername = groupCreatorCache.get(groupId);
+
+		// Kandidaten: alle bekannten User außer eigenem Account, sortiert
 		List<User> candidates = allKnownUsers.stream()
 			.filter(u -> localUser == null || !u.getUsername().equals(localUser.getUsername()))
 			.sorted((a, b) -> {
@@ -1209,16 +1284,21 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 			return;
 		}
 
-		// Checkboxen für jeden User
+		// Checkboxen: bereits Mitglieder vorausgewählt (abwählbar zum Entfernen)
 		VBox content = new VBox(6);
 		content.setPadding(new Insets(10));
 		List<CheckBox> checkBoxes = new ArrayList<>();
 		for (User u : candidates) {
-			String label = u.getDisplayname() != null && !u.getDisplayname().isBlank()
+			String displayName = u.getDisplayname() != null && !u.getDisplayname().isBlank()
 				? u.getDisplayname() + " (" + u.getUsername() + ")"
 				: u.getUsername();
+			boolean isMember = existingMembers.contains(u.getUsername());
+			boolean isCreator = u.getUsername().equals(creatorUsername);
+			String label = isCreator ? displayName + " (Ersteller)" : (isMember ? displayName + " – bereits Mitglied" : displayName);
 			CheckBox cb = new CheckBox(label);
 			cb.setUserData(u.getUsername());
+			cb.setSelected(isMember || isCreator);
+			if (isCreator) cb.setDisable(true);
 			checkBoxes.add(cb);
 			content.getChildren().add(cb);
 		}
@@ -1228,17 +1308,28 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 		scroll.setPrefHeight(Math.min(candidates.size() * 36.0 + 20, 300));
 
 		Dialog<ButtonType> dialog = new Dialog<>();
-		dialog.setTitle("Mitglied hinzufügen");
-		dialog.setHeaderText("Benutzer auswählen:");
+		dialog.setTitle("Gruppenmitglieder verwalten");
+		dialog.setHeaderText("Mitglieder auswählen – Häkchen entfernen zum Ausschließen:");
 		dialog.getDialogPane().setContent(scroll);
 		dialog.getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
 		Main.themed(dialog);
 
 		dialog.showAndWait().ifPresent(btn -> {
 			if (btn == ButtonType.OK) {
+				Set<String> cache = groupMemberCache.computeIfAbsent(groupId, k -> new java.util.HashSet<>());
 				for (CheckBox cb : checkBoxes) {
-					if (cb.isSelected()) {
-						sendPacket(new AddMemberPacket(groupId, (String) cb.getUserData()));
+					String username = (String) cb.getUserData();
+					boolean wasMember = existingMembers.contains(username);
+					boolean isChecked = cb.isSelected();
+
+					if (!wasMember && isChecked) {
+						// Neu hinzufügen
+						sendPacket(new AddMemberPacket(groupId, username));
+						cache.add(username);
+					} else if (wasMember && !isChecked) {
+						// Entfernen
+						sendPacket(new RemoveMemberPacket(groupId, username));
+						cache.remove(username);
 					}
 				}
 			}
@@ -1499,11 +1590,20 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 			box.setAlignment(Pos.CENTER_LEFT);
 			box.setPadding(new Insets(6, 10, 6, 10));
 
-			if (item.type() == ChatEntry.Type.GROUP) {
+			// Globaler Chat (Type.GLOBAL) kriegt kein Menü – alle anderen schon
+			if (item.type() != ChatEntry.Type.GLOBAL) {
 				ContextMenu ctx = new ContextMenu();
-				MenuItem addMember = new MenuItem("Mitglied hinzufügen");
-				addMember.setOnAction(e -> showAddMemberDialog(item.groupId()));
-				ctx.getItems().add(addMember);
+
+				if (item.type() == ChatEntry.Type.GROUP && !removedGroups.contains(item.groupId())) {
+					MenuItem manageMember = new MenuItem("Mitglieder verwalten");
+					manageMember.setOnAction(e -> showAddMemberDialog(item.groupId()));
+					ctx.getItems().add(manageMember);
+				}
+
+				MenuItem removeChat = new MenuItem("Chat entfernen");
+				removeChat.setOnAction(e -> chatList.remove(item));
+				ctx.getItems().add(removeChat);
+
 				setContextMenu(ctx);
 			}
 

--- a/src/main/java/Client/Controller.java
+++ b/src/main/java/Client/Controller.java
@@ -16,6 +16,8 @@ import Util.Network.Auth.RegisterResponse;
 import Util.Network.ConnectionClosed;
 import Util.Network.DeleteForMeMessage;
 import Util.Network.DeleteMessage;
+import Util.Network.GetUsersRequest;
+import Util.Network.GetUsersResponse;
 import Util.Network.Groups.AddMemberPacket;
 import Util.Network.Groups.CreateGroupPacket;
 import Util.Network.Groups.Group;
@@ -100,6 +102,7 @@ public class Controller {
 	private Group activeGroup = null;
 
 	private final ObservableList<ChatEntry> chatList = FXCollections.observableArrayList();
+	private final ObservableList<User> allKnownUsers = FXCollections.observableArrayList();
 	private final Map<String, byte[]> profilePicturesByUsername = new HashMap<>();
 	private final Map<String, String> profilePictureContentTypesByUsername = new HashMap<>();
 	private boolean profilePictureSyncEnabled;
@@ -321,7 +324,10 @@ public class Controller {
 								addGroupToChatList(created.getGroup());
 								openGroupChat(created.getGroup());
 							});
-							case ProfilePictureUpdate update -> Platform.runLater(() -> applyProfilePictureUpdate(update));
+							case GetUsersResponse resp -> Platform.runLater(() -> {
+							allKnownUsers.setAll(resp.getUsers());
+						});
+						case ProfilePictureUpdate update -> Platform.runLater(() -> applyProfilePictureUpdate(update));
 							case ConnectionClosed closed -> Platform.runLater(() -> handleConnectionClosed(closed));
 							case LoginResponse loginResp -> Platform.runLater(() -> { //FÜR UI CALLBACK
 								handleLoginResponse(loginResp);
@@ -661,6 +667,7 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 	private void handleLoginResponse(LoginResponse response) {
 		if (response.getStatus() == Status.SUCCESS) {
 			this.localUser = response.getUser();
+			outPacketQueue.offer(new GetUsersRequest());
 
 			cacheProfilePicture(localUser);
 			updateWelcomeLabel();
@@ -1182,12 +1189,54 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 	}
 
 	private void showAddMemberDialog(UUID groupId) {
-		TextInputDialog dialog = new TextInputDialog();
+		// Kandidaten: alle bekannten User außer dem eigenen Account
+		List<User> candidates = allKnownUsers.stream()
+			.filter(u -> localUser == null || !u.getUsername().equals(localUser.getUsername()))
+			.sorted((a, b) -> {
+				String na = a.getDisplayname() != null && !a.getDisplayname().isBlank() ? a.getDisplayname() : a.getUsername();
+				String nb = b.getDisplayname() != null && !b.getDisplayname().isBlank() ? b.getDisplayname() : b.getUsername();
+				return na.compareToIgnoreCase(nb);
+			})
+			.collect(Collectors.toList());
+
+		if (candidates.isEmpty()) {
+			Alert alert = new Alert(Alert.AlertType.INFORMATION, "Keine Benutzer gefunden.");
+			Main.themed(alert).show();
+			return;
+		}
+
+		// Checkboxen für jeden User
+		VBox content = new VBox(6);
+		content.setPadding(new Insets(10));
+		List<CheckBox> checkBoxes = new ArrayList<>();
+		for (User u : candidates) {
+			String label = u.getDisplayname() != null && !u.getDisplayname().isBlank()
+				? u.getDisplayname() + " (" + u.getUsername() + ")"
+				: u.getUsername();
+			CheckBox cb = new CheckBox(label);
+			cb.setUserData(u.getUsername());
+			checkBoxes.add(cb);
+			content.getChildren().add(cb);
+		}
+
+		ScrollPane scroll = new ScrollPane(content);
+		scroll.setFitToWidth(true);
+		scroll.setPrefHeight(Math.min(candidates.size() * 36.0 + 20, 300));
+
+		Dialog<ButtonType> dialog = new Dialog<>();
 		dialog.setTitle("Mitglied hinzufügen");
-		dialog.setHeaderText("Benutzername eingeben:");
-		Main.themed(dialog).showAndWait().ifPresent(username -> {
-			if (!username.isBlank()) {
-				sendPacket(new AddMemberPacket(groupId, username.trim()));
+		dialog.setHeaderText("Benutzer auswählen:");
+		dialog.getDialogPane().setContent(scroll);
+		dialog.getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
+		Main.themed(dialog);
+
+		dialog.showAndWait().ifPresent(btn -> {
+			if (btn == ButtonType.OK) {
+				for (CheckBox cb : checkBoxes) {
+					if (cb.isSelected()) {
+						sendPacket(new AddMemberPacket(groupId, (String) cb.getUserData()));
+					}
+				}
 			}
 		});
 	}

--- a/src/main/java/Client/Controller.java
+++ b/src/main/java/Client/Controller.java
@@ -686,6 +686,7 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 			cacheProfilePicture(localUser);
 			updateWelcomeLabel();
 			addUserToList(localUser);
+			outPacketQueue.offer(new GetUsersRequest());
 		}
 
 		if (onRegisterResult != null) {
@@ -1189,6 +1190,9 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 	}
 
 	private void showAddMemberDialog(UUID groupId) {
+		// Aktuelle Liste vom Server anfordern, dann Dialog öffnen
+		outPacketQueue.offer(new GetUsersRequest());
+
 		// Kandidaten: alle bekannten User außer dem eigenen Account
 		List<User> candidates = allKnownUsers.stream()
 			.filter(u -> localUser == null || !u.getUsername().equals(localUser.getUsername()))

--- a/src/main/java/Client/Main.java
+++ b/src/main/java/Client/Main.java
@@ -43,7 +43,7 @@ public class Main extends Application {
 		}
 		// Audio - Beim Schließen des Fensters den Anruf beenden
 		primaryStage.setOnCloseRequest(e -> {
-			chatController.stopCall();
+			chatController.disconnect();
 			Platform.exit();
 			System.exit(0);
 		});

--- a/src/main/java/Client/Main.java
+++ b/src/main/java/Client/Main.java
@@ -38,7 +38,7 @@ public class Main extends Application {
 		Controller chatController = chatLoader.getController();
 		chatController.configure(primaryStage, null);
 		// Server IP: 217.154.156.40 und lokal einfach localhost verwenden bzw. ip vom rechner im Labor Netzwerk
-		if (!chatController.connectAndRun("192.168.0.6", 3299)) {
+		if (!chatController.connectAndRun("localhost", 3299)) {
 			return;
 		}
 		// Audio - Beim Schließen des Fensters den Anruf beenden

--- a/src/main/java/Client/Main.java
+++ b/src/main/java/Client/Main.java
@@ -6,6 +6,7 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Dialog;
+import javafx.scene.image.Image;
 import javafx.stage.Stage;
 
 import java.io.IOException;
@@ -61,6 +62,9 @@ public class Main extends Application {
 
 		Scene loginScene = new Scene(loginRoot, 1280, 720);
 		loginScene.getStylesheets().add(CUPERTINO_DARK_CSS);
+
+		var logo = Main.class.getResourceAsStream("/Client/assets/logo2.png");
+		if (logo != null) primaryStage.getIcons().add(new Image(logo));
 
 		primaryStage.setTitle("Socket Chat - Login");
 		primaryStage.setScene(loginScene);

--- a/src/main/java/Client/Main.java
+++ b/src/main/java/Client/Main.java
@@ -44,6 +44,7 @@ public class Main extends Application {
 		}
 		// Audio - Beim Schließen des Fensters den Anruf beenden
 		primaryStage.setOnCloseRequest(e -> {
+			chatController.stopCall();
 			chatController.disconnect();
 			Platform.exit();
 			System.exit(0);

--- a/src/main/java/Server/GroupManager.java
+++ b/src/main/java/Server/GroupManager.java
@@ -38,7 +38,12 @@ public class GroupManager
 	public void registerClient(ClientProxy client, User user)
 	{
 		clientUsers.put(client, user);
-		groupMembers.get(BROADCAST_ID).add(client);
+
+		// Broadcast nur beitreten wenn der User nicht explizit entfernt wurde
+		List<String> removedIds = groupRepository.getRemovedGroupIdsForUser(user.getUsername());
+		if (!removedIds.contains(BROADCAST_ID.toString())) {
+			groupMembers.get(BROADCAST_ID).add(client);
+		}
 
 		for (String groupIdStr : groupRepository.getGroupIdsForUser(user.getUsername())) {
 			try {
@@ -131,6 +136,17 @@ public class GroupManager
 		return result;
 	}
 
+	public List<String> getRemovedGroupIdsForUser(String username)
+	{
+		return groupRepository.getRemovedGroupIdsForUser(username);
+	}
+
+	public Set<String> getMemberUsernames(UUID groupId)
+	{
+		List<String> fromDb = groupRepository.getMembersForGroup(groupId.toString());
+		return new java.util.HashSet<>(fromDb);
+	}
+
 	public boolean addMemberByUsername(UUID groupId, String username, Map<String, ClientProxy> onlineClients)
 	{
 		Set<ClientProxy> members = groupMembers.get(groupId);
@@ -142,5 +158,20 @@ public class GroupManager
 		if (client != null) members.add(client);
 
 		return true;
+	}
+
+	// Gibt den ClientProxy des entfernten Users zurück (null wenn offline), damit der Server ihm eine Benachrichtigung schicken kann.
+	public ClientProxy removeMemberByUsername(UUID groupId, String username, Map<String, ClientProxy> onlineClients)
+	{
+		Set<ClientProxy> members = groupMembers.get(groupId);
+		if (members == null) return null;
+
+		groupRepository.removeMember(groupId, username);
+		groupRepository.markAsRemoved(groupId, username);
+
+		ClientProxy client = onlineClients.get(username);
+		if (client != null) members.remove(client);
+
+		return client;
 	}
 }

--- a/src/main/java/Server/GroupManager.java
+++ b/src/main/java/Server/GroupManager.java
@@ -1,42 +1,54 @@
 package Server;
 
-import Util.Network.Groups.Group;
+import User.Model.ChatGroup;
 import User.Model.User;
+import User.Repository.GroupRepository;
+import Util.Network.Groups.Group;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-// manages all groups on the server side.
-// keeps track of which groups exist, which clients are in each group, and which user belongs to each client.
-// this class is only used internally by the server — clients interact with groups by sending packets.
 public class GroupManager
 {
 	public static final UUID BROADCAST_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
 	public static final String BROADCAST_NAME = "📢 Ankündigungen";
 
 	private final Map<UUID, Group> groups = new ConcurrentHashMap<>();
-	// maps each group id to the set of clients currently in that group
 	private final Map<UUID, Set<ClientProxy>> groupMembers = new ConcurrentHashMap<>();
-	// maps each connected client to their logged-in user object
 	private final Map<ClientProxy, User> clientUsers = new ConcurrentHashMap<>();
+	private final GroupRepository groupRepository;
 
-	public GroupManager() {
+	public GroupManager(GroupRepository groupRepository) {
+		this.groupRepository = groupRepository;
+
+		groupRepository.saveGroup(BROADCAST_ID, BROADCAST_NAME, "System");
 		Group broadcast = new Group(BROADCAST_ID, BROADCAST_NAME, "System");
 		groups.put(BROADCAST_ID, broadcast);
 		groupMembers.put(BROADCAST_ID, Collections.synchronizedSet(new HashSet<>()));
+
+		for (ChatGroup cg : groupRepository.getAllGroups()) {
+			UUID id = cg.getId();
+			if (groups.containsKey(id)) continue;
+			Group g = new Group(id, cg.getName(), cg.getCreatorUsername());
+			groups.put(id, g);
+			groupMembers.put(id, Collections.synchronizedSet(new HashSet<>()));
+		}
 	}
 
-	// ---- client registration ----
-
-	// call this after a client successfully logs in so the group manager knows who they are
 	public void registerClient(ClientProxy client, User user)
 	{
 		clientUsers.put(client, user);
-		// auto-join broadcast channel
 		groupMembers.get(BROADCAST_ID).add(client);
+
+		for (String groupIdStr : groupRepository.getGroupIdsForUser(user.getUsername())) {
+			try {
+				UUID groupId = UUID.fromString(groupIdStr);
+				Set<ClientProxy> members = groupMembers.get(groupId);
+				if (members != null) members.add(client);
+			} catch (IllegalArgumentException ignored) {}
+		}
 	}
 
-	// call this when a client disconnects — removes them from all groups automatically
 	public void unregisterClient(ClientProxy client)
 	{
 		clientUsers.remove(client);
@@ -49,10 +61,6 @@ public class GroupManager
 		return clientUsers.get(client);
 	}
 
-	// ---- group management ----
-
-	// creates a new group with a random uuid and adds the creator as the first member.
-	// returns the created Group object which contains the id needed to join or send messages to the group.
 	public Group createGroup(String name, ClientProxy creator)
 	{
 		User user = clientUsers.get(creator);
@@ -60,6 +68,9 @@ public class GroupManager
 
 		UUID id = UUID.randomUUID();
 		Group group = new Group(id, name, creatorName);
+
+		groupRepository.saveGroup(id, name, creatorName);
+		if (user != null) groupRepository.addMember(id, creatorName);
 
 		groups.put(id, group);
 		Set<ClientProxy> members = Collections.synchronizedSet(new HashSet<>());
@@ -69,16 +80,18 @@ public class GroupManager
 		return group;
 	}
 
-	// adds a client to an existing group. returns false if the group doesn't exist.
 	public boolean joinGroup(UUID groupId, ClientProxy client)
 	{
 		Set<ClientProxy> members = groupMembers.get(groupId);
 		if (members == null) return false;
+
+		User user = clientUsers.get(client);
+		if (user != null) groupRepository.addMember(groupId, user.getUsername());
+
 		members.add(client);
 		return true;
 	}
 
-	// removes a client from a group. returns false if the group doesn't exist.
 	public boolean leaveGroup(UUID groupId, ClientProxy client)
 	{
 		Set<ClientProxy> members = groupMembers.get(groupId);
@@ -86,14 +99,12 @@ public class GroupManager
 		return members.remove(client);
 	}
 
-	// checks if a client is currently in a group
 	public boolean isMember(UUID groupId, ClientProxy client)
 	{
 		Set<ClientProxy> members = groupMembers.get(groupId);
 		return members != null && members.contains(client);
 	}
 
-	// returns all clients currently in a group — used by packetbroker to route group messages
 	public Set<ClientProxy> getGroupMembers(UUID groupId)
 	{
 		return groupMembers.getOrDefault(groupId, Collections.emptySet());
@@ -104,13 +115,11 @@ public class GroupManager
 		return groups.get(groupId);
 	}
 
-	// returns all groups that currently exist on the server
 	public Collection<Group> getAllGroups()
 	{
 		return groups.values();
 	}
 
-	// returns all groups that the given client is currently a member of
 	public Collection<Group> getGroupsForClient(ClientProxy client)
 	{
 		List<Group> result = new ArrayList<>();
@@ -120,5 +129,18 @@ public class GroupManager
 				result.add(groups.get(entry.getKey()));
 		}
 		return result;
+	}
+
+	public boolean addMemberByUsername(UUID groupId, String username, Map<String, ClientProxy> onlineClients)
+	{
+		Set<ClientProxy> members = groupMembers.get(groupId);
+		if (members == null) return false;
+
+		groupRepository.addMember(groupId, username);
+
+		ClientProxy client = onlineClients.get(username);
+		if (client != null) members.add(client);
+
+		return true;
 	}
 }

--- a/src/main/java/Server/PacketBroker.java
+++ b/src/main/java/Server/PacketBroker.java
@@ -224,7 +224,7 @@ public class PacketBroker implements Runnable {
 						}
 					}
 					case GetUsersRequest ignored -> {
-						if (sender != null) {
+						if (sender != null && sender.getUser() != null) {
 							try {
 								// Einfache Kopien ohne Hibernate-Proxies erstellen
 								List<User> simple = userRepository.getAllUsers().stream().map(u -> {

--- a/src/main/java/Server/PacketBroker.java
+++ b/src/main/java/Server/PacketBroker.java
@@ -30,6 +30,8 @@ import Util.Network.Notifications.JoinNotification;
 import Util.Network.Messages.TextMessage;
 import Util.Network.Notifications.LeaveNotification;
 import Util.Network.Packet;
+import Util.Network.GetUsersRequest;
+import Util.Network.GetUsersResponse;
 import Util.Network.ReadReceipt;
 import Util.Network.SocketProxy;
 
@@ -58,6 +60,7 @@ public class PacketBroker implements Runnable {
 	private final ChatHistoryService chatHistoryService;
 	private final DeletedForUserRepository deletedForUserRepository;
 	private final GroupManager groupManager;
+	private final JPAUserRepository userRepository;
 
 	/// Queue für Pakete, die an alle verbundenen Clients gesendet werden sollen.
 	private final BlockingQueue<IncomingPacket> broadcastPacketQueue;
@@ -77,6 +80,7 @@ public class PacketBroker implements Runnable {
 		this.chatHistoryService = new ChatHistoryService();
 		this.deletedForUserRepository = new DeletedForUserRepository();
 		this.groupManager = new GroupManager(new GroupRepository());
+		this.userRepository = new JPAUserRepository();
 
 		this.broadcastPacketQueue = new ArrayBlockingQueue<>(MAX_INCOMING_PACKETS);
 		this.clients = new ArrayList<>(MAX_CLIENTS);
@@ -171,6 +175,15 @@ public class PacketBroker implements Runnable {
 					case MyGroupsRequestPacket ignored -> {
 						if (sender != null)
 							sender.tryEnqueuePacket(new GroupListResponsePacket(groupManager.getGroupsForClient(sender)));
+					}
+					case GetUsersRequest ignored -> {
+						if (sender != null) {
+							try {
+								sender.tryEnqueuePacket(new GetUsersResponse(userRepository.getAllUsers()));
+							} catch (Exception e) {
+								System.err.println("Fehler beim Laden aller Benutzer: " + e);
+							}
+						}
 					}
 					case FileMessage file -> {
 						if (sender != null && sender.getUser() != null) {

--- a/src/main/java/Server/PacketBroker.java
+++ b/src/main/java/Server/PacketBroker.java
@@ -13,6 +13,8 @@ import Util.Network.Auth.RegisterRequest;
 import Util.Network.DeleteForMeMessage;
 import Util.Network.DeleteMessage;
 import Util.Network.EditMessage;
+import User.Repository.GroupRepository;
+import Util.Network.Groups.AddMemberPacket;
 import Util.Network.Groups.CreateGroupPacket;
 import Util.Network.Groups.Group;
 import Util.Network.Groups.GroupCreatedPacket;
@@ -33,10 +35,13 @@ import Util.Network.SocketProxy;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.UUID;
 
@@ -71,7 +76,7 @@ public class PacketBroker implements Runnable {
 		this.chatHistoryHandler = chatHistoryHandler;
 		this.chatHistoryService = new ChatHistoryService();
 		this.deletedForUserRepository = new DeletedForUserRepository();
-		this.groupManager = new GroupManager();
+		this.groupManager = new GroupManager(new GroupRepository());
 
 		this.broadcastPacketQueue = new ArrayBlockingQueue<>(MAX_INCOMING_PACKETS);
 		this.clients = new ArrayList<>(MAX_CLIENTS);
@@ -83,7 +88,8 @@ public class PacketBroker implements Runnable {
 		while (!stopFlag.get() && !Thread.currentThread().isInterrupted()) {
 			try {
 				cleanupDisconnectedClients();
-				IncomingPacket incoming = broadcastPacketQueue.take();
+				IncomingPacket incoming = broadcastPacketQueue.poll(3, TimeUnit.SECONDS);
+				if (incoming == null) continue;
 				Packet packet = incoming.packet();
 				ClientProxy sender = incoming.sender();
 
@@ -141,6 +147,22 @@ public class PacketBroker implements Runnable {
 					case LeaveGroupPacket lgp -> {
 						if (sender != null && sender.getUser() != null)
 							groupManager.leaveGroup(lgp.getGroupId(), sender);
+					}
+					case AddMemberPacket amp -> {
+						if (sender != null && sender.getUser() != null) {
+							Map<String, ClientProxy> online = new HashMap<>();
+							synchronized (clients) {
+								for (var c : clients) {
+									if (c.getUser() != null) online.put(c.getUser().getUsername(), c);
+								}
+							}
+							if (groupManager.addMemberByUsername(amp.getGroupId(), amp.getUsername(), online)) {
+								ClientProxy added = online.get(amp.getUsername());
+								if (added != null) {
+									added.tryEnqueuePacket(new GroupListResponsePacket(groupManager.getGroupsForClient(added)));
+								}
+							}
+						}
 					}
 					case GroupListRequestPacket ignored -> {
 						if (sender != null)

--- a/src/main/java/Server/PacketBroker.java
+++ b/src/main/java/Server/PacketBroker.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
@@ -179,9 +180,16 @@ public class PacketBroker implements Runnable {
 					case GetUsersRequest ignored -> {
 						if (sender != null) {
 							try {
-								sender.tryEnqueuePacket(new GetUsersResponse(userRepository.getAllUsers()));
+								// Einfache Kopien ohne Hibernate-Proxies erstellen
+								List<User> simple = userRepository.getAllUsers().stream().map(u -> {
+									User copy = new User(u.getUsername());
+									copy.setDisplayname(u.getDisplayname());
+									return copy;
+								}).collect(Collectors.toList());
+								sender.tryEnqueuePacket(new GetUsersResponse(simple));
 							} catch (Exception e) {
 								System.err.println("Fehler beim Laden aller Benutzer: " + e);
+								e.printStackTrace();
 							}
 						}
 					}

--- a/src/main/java/Server/PacketBroker.java
+++ b/src/main/java/Server/PacketBroker.java
@@ -15,6 +15,11 @@ import Util.Network.DeleteMessage;
 import Util.Network.EditMessage;
 import User.Repository.GroupRepository;
 import Util.Network.Groups.AddMemberPacket;
+import Util.Network.Groups.GetGroupMembersRequest;
+import Util.Network.Groups.GetGroupMembersResponse;
+import Util.Network.Groups.GroupRemovedNotification;
+import Util.Network.Groups.RemoveMemberPacket;
+import Util.Network.Groups.RemovedGroupsResponse;
 import Util.Network.Groups.CreateGroupPacket;
 import Util.Network.Groups.Group;
 import Util.Network.Groups.GroupCreatedPacket;
@@ -40,6 +45,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -110,6 +116,18 @@ public class PacketBroker implements Runnable {
 
 							// Dem Client die Gruppen schicken, in denen er Mitglied ist (inkl. Broadcast)
 							sender.tryEnqueuePacket(new GroupListResponsePacket(groupManager.getGroupsForClient(sender)));
+							// Dem Client mitteilen aus welchen Gruppen er entfernt wurde (für Lesezugriff)
+							List<String> removedIds = groupManager.getRemovedGroupIdsForUser(user.getUsername());
+							if (!removedIds.isEmpty()) {
+								Map<String, String> removedMap = new java.util.HashMap<>();
+								for (String gid : removedIds) {
+									try {
+										Group g = groupManager.getGroup(UUID.fromString(gid));
+										removedMap.put(gid, g != null ? g.getName() : gid);
+									} catch (IllegalArgumentException ignored) {}
+								}
+								sender.tryEnqueuePacket(new RemovedGroupsResponse(removedMap));
+							}
 
 										// Sende dem neu angemeldeten Client die bereits verbundenen Benutzer,
 										// damit dieser deren Profilbilder direkt laden und cachen kann.
@@ -176,6 +194,34 @@ public class PacketBroker implements Runnable {
 					case MyGroupsRequestPacket ignored -> {
 						if (sender != null)
 							sender.tryEnqueuePacket(new GroupListResponsePacket(groupManager.getGroupsForClient(sender)));
+					}
+					case GetGroupMembersRequest req -> {
+						if (sender != null) {
+							Set<String> members = groupManager.getMemberUsernames(req.getGroupId());
+							Group g = groupManager.getGroup(req.getGroupId());
+							String creator = g != null ? g.getCreatorUsername() : null;
+							sender.tryEnqueuePacket(new GetGroupMembersResponse(req.getGroupId(), members, creator));
+						}
+					}
+					case RemoveMemberPacket rmp -> {
+						if (sender != null && sender.getUser() != null) {
+							Group group = groupManager.getGroup(rmp.getGroupId());
+							// Creator kann nicht entfernt werden
+							if (group != null && rmp.getUsername().equals(group.getCreatorUsername())) break;
+							Map<String, ClientProxy> online = new HashMap<>();
+							synchronized (clients) {
+								for (var c : clients) {
+									if (c.getUser() != null) online.put(c.getUser().getUsername(), c);
+								}
+							}
+							String groupName = group != null ? group.getName() : "Unbekannte Gruppe";
+							ClientProxy removed = groupManager.removeMemberByUsername(rmp.getGroupId(), rmp.getUsername(), online);
+							if (removed != null) {
+								String removedBy = sender.getUser().getDisplayname() != null && !sender.getUser().getDisplayname().isBlank()
+									? sender.getUser().getDisplayname() : sender.getUser().getUsername();
+								removed.tryEnqueuePacket(new GroupRemovedNotification(rmp.getGroupId(), groupName, removedBy));
+							}
+						}
 					}
 					case GetUsersRequest ignored -> {
 						if (sender != null) {

--- a/src/main/java/Server/PacketBroker.java
+++ b/src/main/java/Server/PacketBroker.java
@@ -173,6 +173,8 @@ public class PacketBroker implements Runnable {
 					}
 					case AddMemberPacket amp -> {
 						if (sender != null && sender.getUser() != null) {
+							if (!groupManager.isMember(amp.getGroupId(), sender)) break;
+							if (!userRepository.usernameExists(amp.getUsername())) break;
 							Map<String, ClientProxy> online = new HashMap<>();
 							synchronized (clients) {
 								for (var c : clients) {

--- a/src/main/java/User/Model/ChatGroup.java
+++ b/src/main/java/User/Model/ChatGroup.java
@@ -1,0 +1,30 @@
+package User.Model;
+
+import jakarta.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "chat_groups")
+public class ChatGroup {
+    @Id
+    @Column(columnDefinition = "VARCHAR(36)")
+    private String id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(name = "creator_username", nullable = false)
+    private String creatorUsername;
+
+    protected ChatGroup() {}
+
+    public ChatGroup(UUID id, String name, String creatorUsername) {
+        this.id = id.toString();
+        this.name = name;
+        this.creatorUsername = creatorUsername;
+    }
+
+    public UUID getId() { return UUID.fromString(id); }
+    public String getName() { return name; }
+    public String getCreatorUsername() { return creatorUsername; }
+}

--- a/src/main/java/User/Model/GroupMember.java
+++ b/src/main/java/User/Model/GroupMember.java
@@ -1,0 +1,27 @@
+package User.Model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "group_members", uniqueConstraints = @UniqueConstraint(columnNames = {"group_id", "username"}))
+public class GroupMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "group_id", nullable = false)
+    private String groupId;
+
+    @Column(nullable = false)
+    private String username;
+
+    protected GroupMember() {}
+
+    public GroupMember(String groupId, String username) {
+        this.groupId = groupId;
+        this.username = username;
+    }
+
+    public String getGroupId() { return groupId; }
+    public String getUsername() { return username; }
+}

--- a/src/main/java/User/Model/RemovedGroupMember.java
+++ b/src/main/java/User/Model/RemovedGroupMember.java
@@ -1,0 +1,24 @@
+package User.Model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "removed_group_members", uniqueConstraints = @UniqueConstraint(columnNames = {"group_id", "username"}))
+public class RemovedGroupMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "group_id", nullable = false)
+    private String groupId;
+
+    @Column(nullable = false)
+    private String username;
+
+    protected RemovedGroupMember() {}
+
+    public RemovedGroupMember(String groupId, String username) {
+        this.groupId = groupId;
+        this.username = username;
+    }
+}

--- a/src/main/java/User/Repository/GroupRepository.java
+++ b/src/main/java/User/Repository/GroupRepository.java
@@ -1,0 +1,57 @@
+package User.Repository;
+
+import DBUtil.Connection;
+import User.Model.ChatGroup;
+import User.Model.GroupMember;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+
+import java.util.List;
+import java.util.UUID;
+
+public class GroupRepository {
+
+    public void saveGroup(UUID id, String name, String creatorUsername) {
+        // ignore if already exists (e.g. broadcast group on every startup)
+        try (EntityManager em = Connection.createEntityManager()) {
+            if (em.find(ChatGroup.class, id.toString()) != null) return;
+            EntityTransaction tx = em.getTransaction();
+            try {
+                tx.begin();
+                em.persist(new ChatGroup(id, name, creatorUsername));
+                tx.commit();
+            } catch (Exception e) {
+                if (tx.isActive()) tx.rollback();
+            }
+        }
+    }
+
+    public void addMember(UUID groupId, String username) {
+        try (EntityManager em = Connection.createEntityManager()) {
+            EntityTransaction tx = em.getTransaction();
+            try {
+                tx.begin();
+                em.persist(new GroupMember(groupId.toString(), username));
+                tx.commit();
+            } catch (Exception e) {
+                if (tx.isActive()) tx.rollback();
+                // unique constraint = already member, ignore
+            }
+        }
+    }
+
+    public List<ChatGroup> getAllGroups() {
+        try (EntityManager em = Connection.createEntityManager()) {
+            return em.createQuery("SELECT g FROM ChatGroup g", ChatGroup.class).getResultList();
+        }
+    }
+
+    public List<String> getGroupIdsForUser(String username) {
+        try (EntityManager em = Connection.createEntityManager()) {
+            return em.createQuery(
+                "SELECT m.groupId FROM GroupMember m WHERE m.username = :u", String.class)
+                .setParameter("u", username)
+                .getResultList();
+        }
+    }
+}

--- a/src/main/java/User/Repository/GroupRepository.java
+++ b/src/main/java/User/Repository/GroupRepository.java
@@ -3,6 +3,7 @@ package User.Repository;
 import DBUtil.Connection;
 import User.Model.ChatGroup;
 import User.Model.GroupMember;
+import User.Model.RemovedGroupMember;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityTransaction;
 
@@ -52,6 +53,54 @@ public class GroupRepository {
                 "SELECT m.groupId FROM GroupMember m WHERE m.username = :u", String.class)
                 .setParameter("u", username)
                 .getResultList();
+        }
+    }
+
+    public List<String> getMembersForGroup(String groupId) {
+        try (EntityManager em = Connection.createEntityManager()) {
+            return em.createQuery(
+                "SELECT m.username FROM GroupMember m WHERE m.groupId = :g", String.class)
+                .setParameter("g", groupId)
+                .getResultList();
+        }
+    }
+
+    public void markAsRemoved(UUID groupId, String username) {
+        try (EntityManager em = Connection.createEntityManager()) {
+            EntityTransaction tx = em.getTransaction();
+            try {
+                tx.begin();
+                em.persist(new RemovedGroupMember(groupId.toString(), username));
+                tx.commit();
+            } catch (Exception e) {
+                if (tx.isActive()) tx.rollback();
+                // unique constraint = already marked, ignore
+            }
+        }
+    }
+
+    public List<String> getRemovedGroupIdsForUser(String username) {
+        try (EntityManager em = Connection.createEntityManager()) {
+            return em.createQuery(
+                "SELECT r.groupId FROM RemovedGroupMember r WHERE r.username = :u", String.class)
+                .setParameter("u", username)
+                .getResultList();
+        }
+    }
+
+    public void removeMember(UUID groupId, String username) {
+        try (EntityManager em = Connection.createEntityManager()) {
+            EntityTransaction tx = em.getTransaction();
+            try {
+                tx.begin();
+                em.createQuery("DELETE FROM GroupMember m WHERE m.groupId = :g AND m.username = :u")
+                    .setParameter("g", groupId.toString())
+                    .setParameter("u", username)
+                    .executeUpdate();
+                tx.commit();
+            } catch (Exception e) {
+                if (tx.isActive()) tx.rollback();
+            }
         }
     }
 }

--- a/src/main/java/User/Repository/GroupRepository.java
+++ b/src/main/java/User/Repository/GroupRepository.java
@@ -23,20 +23,27 @@ public class GroupRepository {
                 tx.commit();
             } catch (Exception e) {
                 if (tx.isActive()) tx.rollback();
+                System.err.println("saveGroup fehlgeschlagen (" + id + "): " + e.getMessage());
             }
         }
     }
 
     public void addMember(UUID groupId, String username) {
         try (EntityManager em = Connection.createEntityManager()) {
+            String gid = groupId.toString();
+            long count = em.createQuery(
+                    "SELECT COUNT(m) FROM GroupMember m WHERE m.groupId = :g AND m.username = :u", Long.class)
+                .setParameter("g", gid).setParameter("u", username)
+                .getSingleResult();
+            if (count > 0) return;
             EntityTransaction tx = em.getTransaction();
             try {
                 tx.begin();
-                em.persist(new GroupMember(groupId.toString(), username));
+                em.persist(new GroupMember(gid, username));
                 tx.commit();
             } catch (Exception e) {
                 if (tx.isActive()) tx.rollback();
-                // unique constraint = already member, ignore
+                System.err.println("addMember fehlgeschlagen (" + groupId + ", " + username + "): " + e.getMessage());
             }
         }
     }

--- a/src/main/java/Util/Network/GetUsersRequest.java
+++ b/src/main/java/Util/Network/GetUsersRequest.java
@@ -1,4 +1,8 @@
 package Util.Network;
 
+import java.io.Serial;
+
 public class GetUsersRequest extends Packet {
+	@Serial
+	private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/Util/Network/GetUsersRequest.java
+++ b/src/main/java/Util/Network/GetUsersRequest.java
@@ -1,0 +1,4 @@
+package Util.Network;
+
+public class GetUsersRequest extends Packet {
+}

--- a/src/main/java/Util/Network/GetUsersResponse.java
+++ b/src/main/java/Util/Network/GetUsersResponse.java
@@ -5,6 +5,7 @@ import User.Model.User;
 import java.util.List;
 
 public class GetUsersResponse extends Packet {
+    private static final long serialVersionUID = 1L;
     private final List<User> users;
 
     public GetUsersResponse(List<User> users) {

--- a/src/main/java/Util/Network/GetUsersResponse.java
+++ b/src/main/java/Util/Network/GetUsersResponse.java
@@ -1,0 +1,17 @@
+package Util.Network;
+
+import User.Model.User;
+
+import java.util.List;
+
+public class GetUsersResponse extends Packet {
+    private final List<User> users;
+
+    public GetUsersResponse(List<User> users) {
+        this.users = users;
+    }
+
+    public List<User> getUsers() {
+        return users;
+    }
+}

--- a/src/main/java/Util/Network/Groups/AddMemberPacket.java
+++ b/src/main/java/Util/Network/Groups/AddMemberPacket.java
@@ -1,0 +1,22 @@
+package Util.Network.Groups;
+
+import Util.Network.Packet;
+
+import java.io.Serial;
+import java.util.UUID;
+
+public class AddMemberPacket extends Packet {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final UUID groupId;
+    private final String username;
+
+    public AddMemberPacket(UUID groupId, String username) {
+        this.groupId = groupId;
+        this.username = username;
+    }
+
+    public UUID getGroupId() { return groupId; }
+    public String getUsername() { return username; }
+}

--- a/src/main/java/Util/Network/Groups/GetGroupMembersRequest.java
+++ b/src/main/java/Util/Network/Groups/GetGroupMembersRequest.java
@@ -1,0 +1,14 @@
+package Util.Network.Groups;
+
+import Util.Network.Packet;
+import java.util.UUID;
+
+public class GetGroupMembersRequest extends Packet {
+    private final UUID groupId;
+
+    public GetGroupMembersRequest(UUID groupId) {
+        this.groupId = groupId;
+    }
+
+    public UUID getGroupId() { return groupId; }
+}

--- a/src/main/java/Util/Network/Groups/GetGroupMembersResponse.java
+++ b/src/main/java/Util/Network/Groups/GetGroupMembersResponse.java
@@ -1,0 +1,21 @@
+package Util.Network.Groups;
+
+import Util.Network.Packet;
+import java.util.Set;
+import java.util.UUID;
+
+public class GetGroupMembersResponse extends Packet {
+    private final UUID groupId;
+    private final Set<String> usernames;
+    private final String creatorUsername;
+
+    public GetGroupMembersResponse(UUID groupId, Set<String> usernames, String creatorUsername) {
+        this.groupId = groupId;
+        this.usernames = usernames;
+        this.creatorUsername = creatorUsername;
+    }
+
+    public UUID getGroupId() { return groupId; }
+    public Set<String> getUsernames() { return usernames; }
+    public String getCreatorUsername() { return creatorUsername; }
+}

--- a/src/main/java/Util/Network/Groups/GroupRemovedNotification.java
+++ b/src/main/java/Util/Network/Groups/GroupRemovedNotification.java
@@ -1,0 +1,20 @@
+package Util.Network.Groups;
+
+import Util.Network.Packet;
+import java.util.UUID;
+
+public class GroupRemovedNotification extends Packet {
+    private final UUID groupId;
+    private final String groupName;
+    private final String removedBy;
+
+    public GroupRemovedNotification(UUID groupId, String groupName, String removedBy) {
+        this.groupId = groupId;
+        this.groupName = groupName;
+        this.removedBy = removedBy;
+    }
+
+    public UUID getGroupId() { return groupId; }
+    public String getGroupName() { return groupName; }
+    public String getRemovedBy() { return removedBy; }
+}

--- a/src/main/java/Util/Network/Groups/RemoveMemberPacket.java
+++ b/src/main/java/Util/Network/Groups/RemoveMemberPacket.java
@@ -1,0 +1,17 @@
+package Util.Network.Groups;
+
+import Util.Network.Packet;
+import java.util.UUID;
+
+public class RemoveMemberPacket extends Packet {
+    private final UUID groupId;
+    private final String username;
+
+    public RemoveMemberPacket(UUID groupId, String username) {
+        this.groupId = groupId;
+        this.username = username;
+    }
+
+    public UUID getGroupId() { return groupId; }
+    public String getUsername() { return username; }
+}

--- a/src/main/java/Util/Network/Groups/RemovedGroupsResponse.java
+++ b/src/main/java/Util/Network/Groups/RemovedGroupsResponse.java
@@ -1,0 +1,15 @@
+package Util.Network.Groups;
+
+import Util.Network.Packet;
+import java.util.Map;
+
+public class RemovedGroupsResponse extends Packet {
+    // groupId -> groupName
+    private final Map<String, String> removedGroups;
+
+    public RemovedGroupsResponse(Map<String, String> removedGroups) {
+        this.removedGroups = removedGroups;
+    }
+
+    public Map<String, String> getRemovedGroups() { return removedGroups; }
+}

--- a/src/main/resources/Client/chatScreen.fxml
+++ b/src/main/resources/Client/chatScreen.fxml
@@ -108,11 +108,38 @@
                 <RowConstraints vgrow="SOMETIMES" />
               </rowConstraints>
                <children>
+                  <HBox alignment="CENTER_RIGHT" prefHeight="84.0" prefWidth="337.0" GridPane.columnIndex="1">
+                     <children>
+                        <Button fx:id="videoCallButton" minWidth="100.0" mnemonicParsing="false" styleClass="rounded" text="Anruf">
+                           <HBox.margin>
+                              <Insets bottom="20.0" left="10.0" right="10.0" top="10.0" />
+                           </HBox.margin>
+                        </Button>
+                        <Button fx:id="videoButton" minWidth="120.0" mnemonicParsing="false" styleClass="rounded" text="Videoanruf">
+                           <HBox.margin>
+                              <Insets bottom="20.0" left="10.0" right="10.0" top="10.0" />
+                           </HBox.margin>
+                        </Button>
+                     </children>
+                     <padding>
+                        <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                     </padding>
+                  </HBox>
                   <Label fx:id="chatHeaderLabel" styleClass="title-3" text="Globaler Chat">
                      <padding>
                         <Insets bottom="10.0" />
                      </padding>
                   </Label>
+                  <VBox alignment="CENTER">
+                     <children>
+                        <Label styleClass="title-3" text="FIA11 Gruppe 1">
+                           <padding>
+                              <Insets bottom="10.0" />
+                           </padding>
+                        </Label>
+                        <ImageView fx:id="remoteVideoView" fitHeight="180.0" fitWidth="240.0" pickOnBounds="true" preserveRatio="true" />
+                     </children>
+                  </VBox>
                </children>
             </GridPane>
             <Separator prefWidth="200.0" GridPane.valignment="BOTTOM" />

--- a/src/main/resources/Client/chatScreen.fxml
+++ b/src/main/resources/Client/chatScreen.fxml
@@ -108,38 +108,11 @@
                 <RowConstraints vgrow="SOMETIMES" />
               </rowConstraints>
                <children>
-                  <HBox alignment="CENTER_RIGHT" prefHeight="84.0" prefWidth="337.0" GridPane.columnIndex="1">
-                     <children>
-                        <Button fx:id="videoCallButton" minWidth="100.0" mnemonicParsing="false" styleClass="rounded" text="Anruf">
-                           <HBox.margin>
-                              <Insets bottom="20.0" left="10.0" right="10.0" top="10.0" />
-                           </HBox.margin>
-                        </Button>
-                        <Button fx:id="videoButton" minWidth="120.0" mnemonicParsing="false" styleClass="rounded" text="Videoanruf">
-                           <HBox.margin>
-                              <Insets bottom="20.0" left="10.0" right="10.0" top="10.0" />
-                           </HBox.margin>
-                        </Button>
-                     </children>
-                     <padding>
-                        <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                     </padding>
-                  </HBox>
                   <Label fx:id="chatHeaderLabel" styleClass="title-3" text="Globaler Chat">
                      <padding>
                         <Insets bottom="10.0" />
                      </padding>
                   </Label>
-                  <VBox alignment="CENTER">
-                     <children>
-                        <Label styleClass="title-3" text="FIA11 Gruppe 1">
-                           <padding>
-                              <Insets bottom="10.0" />
-                           </padding>
-                        </Label>
-                        <ImageView fx:id="remoteVideoView" fitHeight="180.0" fitWidth="240.0" pickOnBounds="true" preserveRatio="true" />
-                     </children>
-                  </VBox>
                </children>
             </GridPane>
             <Separator prefWidth="200.0" GridPane.valignment="BOTTOM" />

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -11,7 +11,8 @@
         <class>User.Model.ContactData</class>
 		<class>User.Model.ChatMessage</class>
 		<class>User.Model.DeletedForUser</class>
-
+		<class>User.Model.ChatGroup</class>
+		<class>User.Model.GroupMember</class>
 
         <properties>
             <property name="hibernate.hbm2ddl.auto" value="update"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -13,6 +13,7 @@
 		<class>User.Model.DeletedForUser</class>
 		<class>User.Model.ChatGroup</class>
 		<class>User.Model.GroupMember</class>
+		<class>User.Model.RemovedGroupMember</class>
 
         <properties>
             <property name="hibernate.hbm2ddl.auto" value="update"/>


### PR DESCRIPTION
### Summary
- Implemented group persistence with `ChatGroup` and `GroupMember` entities.
- Added UI to manage group members, including a dialog to add members.
- Enabled users to rejoin groups on reconnection and see join/leave events in the global chat feed.
- Fixed various UI elements, including call buttons and message deletion functionality.
- Improved stability with better client disconnection handling.

