### PR TITLE
Update user management, group persistence, and UI features

### DIFF
--- a/src/main/java/Client/Controller.java
+++ b/src/main/java/Client/Controller.java
@@ -18,6 +18,8 @@ import Util.Network.DeleteForMeMessage;
 import Util.Network.DeleteMessage;
 import Util.Network.GetUsersRequest;
 import Util.Network.GetUsersResponse;
+import Util.Network.HideChatPacket;
+import Util.Network.HiddenChatsResponse;
 import Util.Network.Groups.AddMemberPacket;
 import Util.Network.Groups.GetGroupMembersRequest;
 import Util.Network.Groups.GetGroupMembersResponse;
@@ -114,6 +116,8 @@ public class Controller {
 	private final Map<UUID, String> groupCreatorCache = new HashMap<>();
 	// Gruppen aus denen der User entfernt wurde – nur lesen, nicht schreiben
 	private final Set<UUID> removedGroups = new java.util.HashSet<>();
+	// Chats die der User manuell ausgeblendet hat (chatRef = groupId oder "private:<username>")
+	private final Set<String> hiddenChatRefs = new java.util.HashSet<>();
 	private final Map<String, byte[]> profilePicturesByUsername = new HashMap<>();
 	private final Map<String, String> profilePictureContentTypesByUsername = new HashMap<>();
 	private boolean profilePictureSyncEnabled;
@@ -341,6 +345,13 @@ public class Controller {
 								groupMemberCache.put(resp.getGroupId(), resp.getUsernames());
 								if (resp.getCreatorUsername() != null)
 									groupCreatorCache.put(resp.getGroupId(), resp.getCreatorUsername());
+							});
+							case HiddenChatsResponse resp -> Platform.runLater(() -> {
+								hiddenChatRefs.addAll(resp.getChatRefs());
+								chatList.removeIf(e -> {
+									String ref = chatRefFor(e);
+									return ref != null && hiddenChatRefs.contains(ref);
+								});
 							});
 							case RemovedGroupsResponse resp -> Platform.runLater(() -> {
 								for (Map.Entry<String, String> entry : resp.getRemovedGroups().entrySet()) {
@@ -837,7 +848,17 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 		}
 	}
 
+	private String chatRefFor(ChatEntry e) {
+		return switch (e.type()) {
+			case GROUP -> e.groupId() != null ? e.groupId().toString() : null;
+			case PRIVATE -> e.username() != null ? "private:" + e.username() : null;
+			case GLOBAL -> null;
+		};
+	}
+
 	private void addGroupToChatList(Group group) {
+		String ref = group.getId().toString();
+		if (hiddenChatRefs.contains(ref)) return;
 		for (ChatEntry e : chatList) {
 			if (e.type() == ChatEntry.Type.GROUP && group.getId().equals(e.groupId())) return;
 		}
@@ -845,6 +866,8 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 	}
 
 	private void addPrivateChatToChatList(String username, String displayName) {
+		String ref = "private:" + username;
+		if (hiddenChatRefs.contains(ref)) return;
 		for (ChatEntry e : chatList) {
 			if (e.type() == ChatEntry.Type.PRIVATE && username.equals(e.username())) return;
 		}
@@ -1601,7 +1624,14 @@ case null, default -> System.err.println("Unbekanntes Paket empfangen: " + (pack
 				}
 
 				MenuItem removeChat = new MenuItem("Chat entfernen");
-				removeChat.setOnAction(e -> chatList.remove(item));
+				removeChat.setOnAction(e -> {
+					String ref = chatRefFor(item);
+					if (ref != null) {
+						hiddenChatRefs.add(ref);
+						outPacketQueue.offer(new HideChatPacket(ref));
+					}
+					chatList.remove(item);
+				});
 				ctx.getItems().add(removeChat);
 
 				setContextMenu(ctx);

--- a/src/main/java/Server/GroupManager.java
+++ b/src/main/java/Server/GroupManager.java
@@ -136,6 +136,16 @@ public class GroupManager
 		return result;
 	}
 
+	public void deleteGroup(UUID groupId) {
+		groups.remove(groupId);
+		groupMembers.remove(groupId);
+		groupRepository.deleteGroup(groupId);
+	}
+
+	public boolean allMembersHidden(UUID groupId) {
+		return groupRepository.allMembersHidden(groupId);
+	}
+
 	public List<String> getRemovedGroupIdsForUser(String username)
 	{
 		return groupRepository.getRemovedGroupIdsForUser(username);

--- a/src/main/java/Server/PacketBroker.java
+++ b/src/main/java/Server/PacketBroker.java
@@ -150,6 +150,8 @@ public class PacketBroker implements Runnable {
 								Thread.currentThread().interrupt();
 								return;
 							}
+							// Alle Clients mit der aktuellen Benutzerliste aktualisieren
+							broadcastUserList();
 						}
 					}
 					case RegisterRequest req -> authHandler.handleRegister(req, sender);
@@ -486,6 +488,19 @@ public class PacketBroker implements Runnable {
 		}
 
 		return broadcastPacketQueue.offer(new IncomingPacket(packet, null));
+	}
+
+	private void broadcastUserList() {
+		try {
+			List<User> simple = userRepository.getAllUsers().stream().map(u -> {
+				User copy = new User(u.getUsername());
+				copy.setDisplayname(u.getDisplayname());
+				return copy;
+			}).collect(Collectors.toList());
+			broadcastToAll(new GetUsersResponse(simple));
+		} catch (Exception e) {
+			System.err.println("Fehler beim Broadcasten der Benutzerliste: " + e.getMessage());
+		}
 	}
 
 	public void shutdown() {

--- a/src/main/java/Server/PacketBroker.java
+++ b/src/main/java/Server/PacketBroker.java
@@ -257,6 +257,15 @@ public class PacketBroker implements Runnable {
 					case HideChatPacket hcp -> {
 						if (sender != null && sender.getUser() != null) {
 							hiddenChatRepository.hide(sender.getUser().getUsername(), hcp.getChatRef());
+							// Gruppe komplett löschen wenn alle Mitglieder sie entfernt haben
+							try {
+								UUID groupId = UUID.fromString(hcp.getChatRef());
+								if (groupManager.getGroup(groupId) != null && groupManager.allMembersHidden(groupId)) {
+									groupManager.deleteGroup(groupId);
+								}
+							} catch (IllegalArgumentException ignored) {
+								// chatRef ist kein UUID → privater Chat, nichts zu löschen
+							}
 						}
 					}
 					case FileMessage file -> {

--- a/src/main/java/Server/PacketBroker.java
+++ b/src/main/java/Server/PacketBroker.java
@@ -112,60 +112,15 @@ public class PacketBroker implements Runnable {
 				switch (packet) {
 					case LoginRequest req -> {
 						if (authHandler.handleLogin(req, sender)) {
-							User user = sender.getUser();
-							// register with group manager so this client can create/join groups
-							groupManager.registerClient(sender, user);
-
-							// History direkt nach Login senden
-							chatHistoryHandler.handleHistoryRequest(new HistoryRequest(user.getUsername(), null, "main"), sender);
-
-							// Dem Client die Gruppen schicken, in denen er Mitglied ist (inkl. Broadcast)
-							sender.tryEnqueuePacket(new GroupListResponsePacket(groupManager.getGroupsForClient(sender)));
-							// Dem Client mitteilen aus welchen Gruppen er entfernt wurde (für Lesezugriff)
-							List<String> removedIds = groupManager.getRemovedGroupIdsForUser(user.getUsername());
-							if (!removedIds.isEmpty()) {
-								Map<String, String> removedMap = new java.util.HashMap<>();
-								for (String gid : removedIds) {
-									try {
-										Group g = groupManager.getGroup(UUID.fromString(gid));
-										removedMap.put(gid, g != null ? g.getName() : gid);
-									} catch (IllegalArgumentException ignored) {}
-								}
-								sender.tryEnqueuePacket(new RemovedGroupsResponse(removedMap));
-							}
-
-							// Versteckte Chats senden
-							List<String> hiddenRefs = hiddenChatRepository.getHiddenRefs(user.getUsername());
-							if (!hiddenRefs.isEmpty()) {
-								sender.tryEnqueuePacket(new HiddenChatsResponse(hiddenRefs));
-							}
-
-										// Sende dem neu angemeldeten Client die bereits verbundenen Benutzer,
-										// damit dieser deren Profilbilder direkt laden und cachen kann.
-										synchronized (clients) {
-											for (var existingClient : clients) {
-												if (existingClient == sender) continue;
-												var existingUser = existingClient.getUser();
-												if (existingUser != null) {
-													// versuche, dem neuen Client eine JoinNotification für den existierenden Benutzer zu senden
-													sender.tryEnqueuePacket(new JoinNotification(existingUser));
-												}
-											}
-										}
-
-							try {
-								if (!broadcast(new JoinNotification(user))) {
-									System.err.println("broadcastPacketQueue ist voll, JoinNotification wurde verworfen");
-								}
-							} catch (InterruptedException e) {
-								Thread.currentThread().interrupt();
-								return;
-							}
-							// Alle Clients mit der aktuellen Benutzerliste aktualisieren
-							broadcastUserList();
+							try { setupAfterAuth(sender); } catch (InterruptedException e) { Thread.currentThread().interrupt(); return; }
 						}
 					}
-					case RegisterRequest req -> authHandler.handleRegister(req, sender);
+					case RegisterRequest req -> {
+						authHandler.handleRegister(req, sender);
+						if (sender != null && sender.getUser() != null) {
+							try { setupAfterAuth(sender); } catch (InterruptedException e) { Thread.currentThread().interrupt(); return; }
+						}
+					}
 					// group action packets — only logged in clients can use these
 					case CreateGroupPacket cgp -> {
 						if (sender != null && sender.getUser() != null) {
@@ -513,6 +468,55 @@ public class PacketBroker implements Runnable {
 		}
 
 		return broadcastPacketQueue.offer(new IncomingPacket(packet, null));
+	}
+
+	private void setupAfterAuth(ClientProxy sender) throws InterruptedException {
+		User user = sender.getUser();
+		groupManager.registerClient(sender, user);
+
+		// Chat-History für globalen Chat senden
+		chatHistoryHandler.handleHistoryRequest(new HistoryRequest(user.getUsername(), null, "main"), sender);
+
+		// Gruppen des Clients senden
+		sender.tryEnqueuePacket(new GroupListResponsePacket(groupManager.getGroupsForClient(sender)));
+
+		// Entfernte Gruppen senden
+		List<String> removedIds = groupManager.getRemovedGroupIdsForUser(user.getUsername());
+		if (!removedIds.isEmpty()) {
+			Map<String, String> removedMap = new java.util.HashMap<>();
+			for (String gid : removedIds) {
+				try {
+					Group g = groupManager.getGroup(UUID.fromString(gid));
+					removedMap.put(gid, g != null ? g.getName() : gid);
+				} catch (IllegalArgumentException ignored) {}
+			}
+			sender.tryEnqueuePacket(new RemovedGroupsResponse(removedMap));
+		}
+
+		// Versteckte Chats senden
+		List<String> hiddenRefs = hiddenChatRepository.getHiddenRefs(user.getUsername());
+		if (!hiddenRefs.isEmpty()) {
+			sender.tryEnqueuePacket(new HiddenChatsResponse(hiddenRefs));
+		}
+
+		// JoinNotifications für alle bereits verbundenen Clients senden
+		synchronized (clients) {
+			for (var existingClient : clients) {
+				if (existingClient == sender) continue;
+				var existingUser = existingClient.getUser();
+				if (existingUser != null) {
+					sender.tryEnqueuePacket(new JoinNotification(existingUser));
+				}
+			}
+		}
+
+		// Allen anderen mitteilen dass ein neuer User da ist
+		if (!broadcast(new JoinNotification(user))) {
+			System.err.println("broadcastPacketQueue ist voll, JoinNotification wurde verworfen");
+		}
+
+		// Benutzerliste bei allen aktualisieren
+		broadcastUserList();
 	}
 
 	private void broadcastUserList() {

--- a/src/main/java/Server/PacketBroker.java
+++ b/src/main/java/Server/PacketBroker.java
@@ -37,7 +37,10 @@ import Util.Network.Notifications.LeaveNotification;
 import Util.Network.Packet;
 import Util.Network.GetUsersRequest;
 import Util.Network.GetUsersResponse;
+import Util.Network.HideChatPacket;
+import Util.Network.HiddenChatsResponse;
 import Util.Network.ReadReceipt;
+import User.Repository.HiddenChatRepository;
 import Util.Network.SocketProxy;
 
 import java.io.IOException;
@@ -68,6 +71,7 @@ public class PacketBroker implements Runnable {
 	private final DeletedForUserRepository deletedForUserRepository;
 	private final GroupManager groupManager;
 	private final JPAUserRepository userRepository;
+	private final HiddenChatRepository hiddenChatRepository;
 
 	/// Queue für Pakete, die an alle verbundenen Clients gesendet werden sollen.
 	private final BlockingQueue<IncomingPacket> broadcastPacketQueue;
@@ -88,6 +92,7 @@ public class PacketBroker implements Runnable {
 		this.deletedForUserRepository = new DeletedForUserRepository();
 		this.groupManager = new GroupManager(new GroupRepository());
 		this.userRepository = new JPAUserRepository();
+		this.hiddenChatRepository = new HiddenChatRepository();
 
 		this.broadcastPacketQueue = new ArrayBlockingQueue<>(MAX_INCOMING_PACKETS);
 		this.clients = new ArrayList<>(MAX_CLIENTS);
@@ -127,6 +132,12 @@ public class PacketBroker implements Runnable {
 									} catch (IllegalArgumentException ignored) {}
 								}
 								sender.tryEnqueuePacket(new RemovedGroupsResponse(removedMap));
+							}
+
+							// Versteckte Chats senden
+							List<String> hiddenRefs = hiddenChatRepository.getHiddenRefs(user.getUsername());
+							if (!hiddenRefs.isEmpty()) {
+								sender.tryEnqueuePacket(new HiddenChatsResponse(hiddenRefs));
 							}
 
 										// Sende dem neu angemeldeten Client die bereits verbundenen Benutzer,
@@ -241,6 +252,11 @@ public class PacketBroker implements Runnable {
 								System.err.println("Fehler beim Laden aller Benutzer: " + e);
 								e.printStackTrace();
 							}
+						}
+					}
+					case HideChatPacket hcp -> {
+						if (sender != null && sender.getUser() != null) {
+							hiddenChatRepository.hide(sender.getUser().getUsername(), hcp.getChatRef());
 						}
 					}
 					case FileMessage file -> {

--- a/src/main/java/User/Model/HiddenChat.java
+++ b/src/main/java/User/Model/HiddenChat.java
@@ -1,0 +1,27 @@
+package User.Model;
+
+import jakarta.persistence.*;
+
+// chatRef: groupId (UUID string) für Gruppen, "private:<username>" für private Chats
+@Entity
+@Table(name = "hidden_chats", uniqueConstraints = @UniqueConstraint(columnNames = {"username", "chat_ref"}))
+public class HiddenChat {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(name = "chat_ref", nullable = false)
+    private String chatRef;
+
+    protected HiddenChat() {}
+
+    public HiddenChat(String username, String chatRef) {
+        this.username = username;
+        this.chatRef = chatRef;
+    }
+
+    public String getChatRef() { return chatRef; }
+}

--- a/src/main/java/User/Repository/GroupRepository.java
+++ b/src/main/java/User/Repository/GroupRepository.java
@@ -3,6 +3,7 @@ package User.Repository;
 import DBUtil.Connection;
 import User.Model.ChatGroup;
 import User.Model.GroupMember;
+import User.Model.HiddenChat;
 import User.Model.RemovedGroupMember;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityTransaction;
@@ -92,6 +93,44 @@ public class GroupRepository {
                 "SELECT r.groupId FROM RemovedGroupMember r WHERE r.username = :u", String.class)
                 .setParameter("u", username)
                 .getResultList();
+        }
+    }
+
+    // Gibt true zurück wenn alle Mitglieder (aktiv + entfernt) die Gruppe versteckt haben
+    public boolean allMembersHidden(UUID groupId) {
+        try (EntityManager em = Connection.createEntityManager()) {
+            String gid = groupId.toString();
+            // Alle die je Mitglied waren (aktiv oder entfernt)
+            long totalMembers = em.createQuery(
+                "SELECT COUNT(m) FROM GroupMember m WHERE m.groupId = :g", Long.class)
+                .setParameter("g", gid).getSingleResult()
+                + em.createQuery(
+                "SELECT COUNT(r) FROM RemovedGroupMember r WHERE r.groupId = :g", Long.class)
+                .setParameter("g", gid).getSingleResult();
+            if (totalMembers == 0) return true;
+            long hiddenCount = em.createQuery(
+                "SELECT COUNT(h) FROM HiddenChat h WHERE h.chatRef = :r", Long.class)
+                .setParameter("r", gid).getSingleResult();
+            return hiddenCount >= totalMembers;
+        }
+    }
+
+    public void deleteGroup(UUID groupId) {
+        try (EntityManager em = Connection.createEntityManager()) {
+            String gid = groupId.toString();
+            EntityTransaction tx = em.getTransaction();
+            try {
+                tx.begin();
+                em.createQuery("DELETE FROM GroupMember m WHERE m.groupId = :g").setParameter("g", gid).executeUpdate();
+                em.createQuery("DELETE FROM RemovedGroupMember r WHERE r.groupId = :g").setParameter("g", gid).executeUpdate();
+                em.createQuery("DELETE FROM HiddenChat h WHERE h.chatRef = :g").setParameter("g", gid).executeUpdate();
+                ChatGroup cg = em.find(ChatGroup.class, gid);
+                if (cg != null) em.remove(cg);
+                tx.commit();
+            } catch (Exception e) {
+                if (tx.isActive()) tx.rollback();
+                System.err.println("deleteGroup fehlgeschlagen (" + groupId + "): " + e.getMessage());
+            }
         }
     }
 

--- a/src/main/java/User/Repository/HiddenChatRepository.java
+++ b/src/main/java/User/Repository/HiddenChatRepository.java
@@ -1,0 +1,39 @@
+package User.Repository;
+
+import DBUtil.Connection;
+import User.Model.HiddenChat;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+
+import java.util.List;
+
+public class HiddenChatRepository {
+
+    public void hide(String username, String chatRef) {
+        try (EntityManager em = Connection.createEntityManager()) {
+            long count = em.createQuery(
+                    "SELECT COUNT(h) FROM HiddenChat h WHERE h.username = :u AND h.chatRef = :r", Long.class)
+                .setParameter("u", username).setParameter("r", chatRef)
+                .getSingleResult();
+            if (count > 0) return;
+            EntityTransaction tx = em.getTransaction();
+            try {
+                tx.begin();
+                em.persist(new HiddenChat(username, chatRef));
+                tx.commit();
+            } catch (Exception e) {
+                if (tx.isActive()) tx.rollback();
+                System.err.println("HiddenChat speichern fehlgeschlagen: " + e.getMessage());
+            }
+        }
+    }
+
+    public List<String> getHiddenRefs(String username) {
+        try (EntityManager em = Connection.createEntityManager()) {
+            return em.createQuery(
+                "SELECT h.chatRef FROM HiddenChat h WHERE h.username = :u", String.class)
+                .setParameter("u", username)
+                .getResultList();
+        }
+    }
+}

--- a/src/main/java/Util/Network/HiddenChatsResponse.java
+++ b/src/main/java/Util/Network/HiddenChatsResponse.java
@@ -1,0 +1,14 @@
+package Util.Network;
+
+import java.util.List;
+
+public class HiddenChatsResponse extends Packet {
+    private static final long serialVersionUID = 1L;
+    private final List<String> chatRefs;
+
+    public HiddenChatsResponse(List<String> chatRefs) {
+        this.chatRefs = chatRefs;
+    }
+
+    public List<String> getChatRefs() { return chatRefs; }
+}

--- a/src/main/java/Util/Network/HideChatPacket.java
+++ b/src/main/java/Util/Network/HideChatPacket.java
@@ -1,0 +1,12 @@
+package Util.Network;
+
+public class HideChatPacket extends Packet {
+    private static final long serialVersionUID = 1L;
+    private final String chatRef;
+
+    public HideChatPacket(String chatRef) {
+        this.chatRef = chatRef;
+    }
+
+    public String getChatRef() { return chatRef; }
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -14,6 +14,7 @@
 		<class>User.Model.ChatGroup</class>
 		<class>User.Model.GroupMember</class>
 		<class>User.Model.RemovedGroupMember</class>
+		<class>User.Model.HiddenChat</class>
 
         <properties>
             <property name="hibernate.hbm2ddl.auto" value="update"/>


### PR DESCRIPTION
```
### Description

This pull request includes the following updates:

- **User Management**: Run post-auth actions after registration to ensure online status is updated. Broadcast user list updates to synchronize member dialogs on login.
- **Group Persistence**: Add group persistence in the database. Handle group deletion when no members remain and preserve the state of hidden/removed chats across sessions.
- **Member Management**: Protect group creators from accidental removal, manage group memberships through dialog, and enforce user verification before actions.
- **UI Improvements**: Add application logo to the login window, restore call buttons in chat screens, and integrate right-click actions for managing chats and groups.

### Code Quality Improvements

- Enhanced security and robustness with better authentication, logging, and error handling. Avoid Hibernate proxy serialization issues.

### Testing

- [ ] Verify user registration updates online information.
- [ ] Ensure group persistence functions correctly.
- [ ] Test UI components for chat and member management functionality.

```